### PR TITLE
Add policy document and supporting files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Ignore rendered doc
+index.html
+index_files/
+
 # History files
 .Rhistory
 .Rapp.history

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,4 +2,4 @@
 # the repo. Unless a later match takes precedence,
 # @primary-owner and @secondary-owner will be requested for
 # review when someone opens a pull request.
-*       @primary-owner @secondary-owner
+*       @ChrisBeeley @matt-dray

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,395 @@
-MIT License
+Attribution 4.0 International
 
-Copyright (c) 2025 The Strategy Unit
+=======================================================================
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Creative Commons Corporation ("Creative Commons") is not a law firm and
+does not provide legal services or legal advice. Distribution of
+Creative Commons public licenses does not create a lawyer-client or
+other relationship. Creative Commons makes its licenses and related
+information available on an "as-is" basis. Creative Commons gives no
+warranties regarding its licenses, any material licensed under their
+terms and conditions, or any related information. Creative Commons
+disclaims all liability for damages resulting from their use to the
+fullest extent possible.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+Using Creative Commons Public Licenses
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+Creative Commons public licenses provide a standard set of terms and
+conditions that creators and other rights holders may use to share
+original works of authorship and other material subject to copyright
+and certain other rights specified in the public license below. The
+following considerations are for informational purposes only, are not
+exhaustive, and do not form part of our licenses.
+
+     Considerations for licensors: Our public licenses are
+     intended for use by those authorized to give the public
+     permission to use material in ways otherwise restricted by
+     copyright and certain other rights. Our licenses are
+     irrevocable. Licensors should read and understand the terms
+     and conditions of the license they choose before applying it.
+     Licensors should also secure all rights necessary before
+     applying our licenses so that the public can reuse the
+     material as expected. Licensors should clearly mark any
+     material not subject to the license. This includes other CC-
+     licensed material, or material used under an exception or
+     limitation to copyright. More considerations for licensors:
+    wiki.creativecommons.org/Considerations_for_licensors
+
+     Considerations for the public: By using one of our public
+     licenses, a licensor grants the public permission to use the
+     licensed material under specified terms and conditions. If
+     the licensor's permission is not necessary for any reason--for
+     example, because of any applicable exception or limitation to
+     copyright--then that use is not regulated by the license. Our
+     licenses grant only permissions under copyright and certain
+     other rights that a licensor has authority to grant. Use of
+     the licensed material may still be restricted for other
+     reasons, including because others have copyright or other
+     rights in the material. A licensor may make special requests,
+     such as asking that all changes be marked or described.
+     Although not required by our licenses, you are encouraged to
+     respect those requests where reasonable. More considerations
+     for the public:
+    wiki.creativecommons.org/Considerations_for_licensees
+
+=======================================================================
+
+Creative Commons Attribution 4.0 International Public License
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution 4.0 International Public License ("Public License"). To the
+extent this Public License may be interpreted as a contract, You are
+granted the Licensed Rights in consideration of Your acceptance of
+these terms and conditions, and the Licensor grants You such rights in
+consideration of benefits the Licensor receives from making the
+Licensed Material available under these terms and conditions.
+
+
+Section 1 -- Definitions.
+
+  a. Adapted Material means material subject to Copyright and Similar
+     Rights that is derived from or based upon the Licensed Material
+     and in which the Licensed Material is translated, altered,
+     arranged, transformed, or otherwise modified in a manner requiring
+     permission under the Copyright and Similar Rights held by the
+     Licensor. For purposes of this Public License, where the Licensed
+     Material is a musical work, performance, or sound recording,
+     Adapted Material is always produced where the Licensed Material is
+     synched in timed relation with a moving image.
+
+  b. Adapter's License means the license You apply to Your Copyright
+     and Similar Rights in Your contributions to Adapted Material in
+     accordance with the terms and conditions of this Public License.
+
+  c. Copyright and Similar Rights means copyright and/or similar rights
+     closely related to copyright including, without limitation,
+     performance, broadcast, sound recording, and Sui Generis Database
+     Rights, without regard to how the rights are labeled or
+     categorized. For purposes of this Public License, the rights
+     specified in Section 2(b)(1)-(2) are not Copyright and Similar
+     Rights.
+
+  d. Effective Technological Measures means those measures that, in the
+     absence of proper authority, may not be circumvented under laws
+     fulfilling obligations under Article 11 of the WIPO Copyright
+     Treaty adopted on December 20, 1996, and/or similar international
+     agreements.
+
+  e. Exceptions and Limitations means fair use, fair dealing, and/or
+     any other exception or limitation to Copyright and Similar Rights
+     that applies to Your use of the Licensed Material.
+
+  f. Licensed Material means the artistic or literary work, database,
+     or other material to which the Licensor applied this Public
+     License.
+
+  g. Licensed Rights means the rights granted to You subject to the
+     terms and conditions of this Public License, which are limited to
+     all Copyright and Similar Rights that apply to Your use of the
+     Licensed Material and that the Licensor has authority to license.
+
+  h. Licensor means the individual(s) or entity(ies) granting rights
+     under this Public License.
+
+  i. Share means to provide material to the public by any means or
+     process that requires permission under the Licensed Rights, such
+     as reproduction, public display, public performance, distribution,
+     dissemination, communication, or importation, and to make material
+     available to the public including in ways that members of the
+     public may access the material from a place and at a time
+     individually chosen by them.
+
+  j. Sui Generis Database Rights means rights other than copyright
+     resulting from Directive 96/9/EC of the European Parliament and of
+     the Council of 11 March 1996 on the legal protection of databases,
+     as amended and/or succeeded, as well as other essentially
+     equivalent rights anywhere in the world.
+
+  k. You means the individual or entity exercising the Licensed Rights
+     under this Public License. Your has a corresponding meaning.
+
+
+Section 2 -- Scope.
+
+  a. License grant.
+
+       1. Subject to the terms and conditions of this Public License,
+          the Licensor hereby grants You a worldwide, royalty-free,
+          non-sublicensable, non-exclusive, irrevocable license to
+          exercise the Licensed Rights in the Licensed Material to:
+
+            a. reproduce and Share the Licensed Material, in whole or
+               in part; and
+
+            b. produce, reproduce, and Share Adapted Material.
+
+       2. Exceptions and Limitations. For the avoidance of doubt, where
+          Exceptions and Limitations apply to Your use, this Public
+          License does not apply, and You do not need to comply with
+          its terms and conditions.
+
+       3. Term. The term of this Public License is specified in Section
+          6(a).
+
+       4. Media and formats; technical modifications allowed. The
+          Licensor authorizes You to exercise the Licensed Rights in
+          all media and formats whether now known or hereafter created,
+          and to make technical modifications necessary to do so. The
+          Licensor waives and/or agrees not to assert any right or
+          authority to forbid You from making technical modifications
+          necessary to exercise the Licensed Rights, including
+          technical modifications necessary to circumvent Effective
+          Technological Measures. For purposes of this Public License,
+          simply making modifications authorized by this Section 2(a)
+          (4) never produces Adapted Material.
+
+       5. Downstream recipients.
+
+            a. Offer from the Licensor -- Licensed Material. Every
+               recipient of the Licensed Material automatically
+               receives an offer from the Licensor to exercise the
+               Licensed Rights under the terms and conditions of this
+               Public License.
+
+            b. No downstream restrictions. You may not offer or impose
+               any additional or different terms or conditions on, or
+               apply any Effective Technological Measures to, the
+               Licensed Material if doing so restricts exercise of the
+               Licensed Rights by any recipient of the Licensed
+               Material.
+
+       6. No endorsement. Nothing in this Public License constitutes or
+          may be construed as permission to assert or imply that You
+          are, or that Your use of the Licensed Material is, connected
+          with, or sponsored, endorsed, or granted official status by,
+          the Licensor or others designated to receive attribution as
+          provided in Section 3(a)(1)(A)(i).
+
+  b. Other rights.
+
+       1. Moral rights, such as the right of integrity, are not
+          licensed under this Public License, nor are publicity,
+          privacy, and/or other similar personality rights; however, to
+          the extent possible, the Licensor waives and/or agrees not to
+          assert any such rights held by the Licensor to the limited
+          extent necessary to allow You to exercise the Licensed
+          Rights, but not otherwise.
+
+       2. Patent and trademark rights are not licensed under this
+          Public License.
+
+       3. To the extent possible, the Licensor waives any right to
+          collect royalties from You for the exercise of the Licensed
+          Rights, whether directly or through a collecting society
+          under any voluntary or waivable statutory or compulsory
+          licensing scheme. In all other cases the Licensor expressly
+          reserves any right to collect such royalties.
+
+
+Section 3 -- License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the
+following conditions.
+
+  a. Attribution.
+
+       1. If You Share the Licensed Material (including in modified
+          form), You must:
+
+            a. retain the following if it is supplied by the Licensor
+               with the Licensed Material:
+
+                 i. identification of the creator(s) of the Licensed
+                    Material and any others designated to receive
+                    attribution, in any reasonable manner requested by
+                    the Licensor (including by pseudonym if
+                    designated);
+
+                ii. a copyright notice;
+
+               iii. a notice that refers to this Public License;
+
+                iv. a notice that refers to the disclaimer of
+                    warranties;
+
+                 v. a URI or hyperlink to the Licensed Material to the
+                    extent reasonably practicable;
+
+            b. indicate if You modified the Licensed Material and
+               retain an indication of any previous modifications; and
+
+            c. indicate the Licensed Material is licensed under this
+               Public License, and include the text of, or the URI or
+               hyperlink to, this Public License.
+
+       2. You may satisfy the conditions in Section 3(a)(1) in any
+          reasonable manner based on the medium, means, and context in
+          which You Share the Licensed Material. For example, it may be
+          reasonable to satisfy the conditions by providing a URI or
+          hyperlink to a resource that includes the required
+          information.
+
+       3. If requested by the Licensor, You must remove any of the
+          information required by Section 3(a)(1)(A) to the extent
+          reasonably practicable.
+
+       4. If You Share Adapted Material You produce, the Adapter's
+          License You apply must not prevent recipients of the Adapted
+          Material from complying with this Public License.
+
+
+Section 4 -- Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that
+apply to Your use of the Licensed Material:
+
+  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
+     to extract, reuse, reproduce, and Share all or a substantial
+     portion of the contents of the database;
+
+  b. if You include all or a substantial portion of the database
+     contents in a database in which You have Sui Generis Database
+     Rights, then the database in which You have Sui Generis Database
+     Rights (but not its individual contents) is Adapted Material; and
+
+  c. You must comply with the conditions in Section 3(a) if You Share
+     all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not
+replace Your obligations under this Public License where the Licensed
+Rights include other Copyright and Similar Rights.
+
+
+Section 5 -- Disclaimer of Warranties and Limitation of Liability.
+
+  a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
+     EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
+     AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
+     ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
+     IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
+     WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
+     PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
+     ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
+     KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
+     ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
+
+  b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
+     TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
+     NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
+     INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
+     COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
+     USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
+     ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
+     DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
+     IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
+
+  c. The disclaimer of warranties and limitation of liability provided
+     above shall be interpreted in a manner that, to the extent
+     possible, most closely approximates an absolute disclaimer and
+     waiver of all liability.
+
+
+Section 6 -- Term and Termination.
+
+  a. This Public License applies for the term of the Copyright and
+     Similar Rights licensed here. However, if You fail to comply with
+     this Public License, then Your rights under this Public License
+     terminate automatically.
+
+  b. Where Your right to use the Licensed Material has terminated under
+     Section 6(a), it reinstates:
+
+       1. automatically as of the date the violation is cured, provided
+          it is cured within 30 days of Your discovery of the
+          violation; or
+
+       2. upon express reinstatement by the Licensor.
+
+     For the avoidance of doubt, this Section 6(b) does not affect any
+     right the Licensor may have to seek remedies for Your violations
+     of this Public License.
+
+  c. For the avoidance of doubt, the Licensor may also offer the
+     Licensed Material under separate terms or conditions or stop
+     distributing the Licensed Material at any time; however, doing so
+     will not terminate this Public License.
+
+  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
+     License.
+
+
+Section 7 -- Other Terms and Conditions.
+
+  a. The Licensor shall not be bound by any additional or different
+     terms or conditions communicated by You unless expressly agreed.
+
+  b. Any arrangements, understandings, or agreements regarding the
+     Licensed Material not stated herein are separate from and
+     independent of the terms and conditions of this Public License.
+
+
+Section 8 -- Interpretation.
+
+  a. For the avoidance of doubt, this Public License does not, and
+     shall not be interpreted to, reduce, limit, restrict, or impose
+     conditions on any use of the Licensed Material that could lawfully
+     be made without permission under this Public License.
+
+  b. To the extent possible, if any provision of this Public License is
+     deemed unenforceable, it shall be automatically reformed to the
+     minimum extent necessary to make it enforceable. If the provision
+     cannot be reformed, it shall be severed from this Public License
+     without affecting the enforceability of the remaining terms and
+     conditions.
+
+  c. No term or condition of this Public License will be waived and no
+     failure to comply consented to unless expressly agreed to by the
+     Licensor.
+
+  d. Nothing in this Public License constitutes or may be interpreted
+     as a limitation upon, or waiver of, any privileges and immunities
+     that apply to the Licensor or You, including from the legal
+     processes of any jurisdiction or authority.
+
+
+=======================================================================
+
+Creative Commons is not a party to its public
+licenses. Notwithstanding, Creative Commons may elect to apply one of
+its public licenses to material it publishes and in those instances
+will be considered the “Licensor.” The text of the Creative Commons
+public licenses is dedicated to the public domain under the CC0 Public
+Domain Dedication. Except for the limited purpose of indicating that
+material is shared under a Creative Commons public license or as
+otherwise permitted by the Creative Commons policies published at
+creativecommons.org/policies, Creative Commons does not authorize the
+use of the trademark "Creative Commons" or any other trademark or logo
+of Creative Commons without its prior written consent including,
+without limitation, in connection with any unauthorized modifications
+to any of its public licenses or any other arrangements,
+understandings, or agreements concerning use of licensed material. For
+the avoidance of doubt, this paragraph does not form part of the
+public licenses.
+
+Creative Commons may be contacted at creativecommons.org.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# template-repository
-A template for repositories with standard Strategy Unit files
+# open-source-policy
+
+A Quarto document containing the open-source policy of [The Strategy Unit](https://www.strategyunitwm.nhs.uk/).

--- a/index.qmd
+++ b/index.qmd
@@ -1,0 +1,111 @@
+---
+title: Open-Source Policy
+author: "[The Strategy Unit](https://www.strategyunitwm.nhs.uk/)"
+date: 2025-04-25
+date-modified: last-modified
+date-format: MMMM D YYYY
+license: CC BY
+format: html
+---
+
+## Introduction
+
+We are public servants providing public services.
+
+The Strategy Unit is therefore committed to maximising public value for the work we do. One significant route to this is disseminating our outputs.
+
+This might mean models, underpinning code, presentations, reports, or anything that usefully communicates the approaches we've used and the results we've arrived at.
+
+Others can then learn from, build upon, adapt and reuse what we have done in a way that would not be possible if outputs were not made public.
+
+So, our default approach is to share our work, through our website, our GitHub organisation, social media and other channels.
+
+Where our customers deem this to be inappropriate—perhaps for reasons of confidentiality, or perhaps because our advice is by nature private to them—then we are happy to discuss this.
+
+## About open source
+
+Open sourcing analytic code to ensure that '[all efforts are made to never solve the same problem twice](https://github.com/nhsx/open-source-policy/blob/main/open-source-policy.md)' was set out as policy in the comparatively recent [Data Saves Lives](https://www.gov.uk/government/publications/data-saves-lives-reshaping-health-and-social-care-with-data) (June 2022):
+
+> Public services are built with public money, and so the code they are based on should be made available across the health and care system, and those working with it, to reuse and build on.
+
+Open sourcing analytic and other code for public benefit is an idea that has been around for a long time.
+The Strategy Unit itself [first published code on GitHub](https://github.com/The-Strategy-Unit/StrategyUnitTheme/commit/c3a521c32d1a0dbe5f85f35636cece76bf58ad20) in November 2019 and the NHS-R community [first published](https://github.com/nhs-r-community/NHSRdatasets/commit/1e69c0a4bf129c002f3645d4ab09ccfae41917bc) in July 2019.
+The R language, which features prominently in both GitHub organisations, is itself open source and was first released in August 1993.
+Open source software is [recorded as early as 1953](https://en.wikipedia.org/wiki/History_of_free_and_open-source_software#Free_software_before_the_1980s), varying in importance in the decades since.
+[The GNU project](https://en.wikipedia.org/wiki/History_of_free_and_open-source_software#Launch_of_the_free_software_movement) in 1983 and [Linux](https://en.wikipedia.org/wiki/History_of_free_and_open-source_software#Linux_(1991%E2%80%93present)) in 1991 were turning points in the history of open source software, and the GNU/Linux project now [controls most of the internet](https://www.wired.com/2016/08/linux-took-web-now-taking-world/) as well as [running on all of the top 500 supercomputers](https://www.networkworld.com/article/3568616/linux-dominates-supercomputing.html) in the world.
+
+## Why open source?
+
+There is a lot of focus on the reuse of analytic code in discussion about open sourcing but in fact there are lots of reasons to open source analytic code.
+
+### Reuse
+
+This is often given as a reason to open source code, including in Data Saves Lives, and it has the potential to save a very large amount of time and money in health and social care.
+There is a great deal of analytic work needlessly done more than once in health and social care and open sourced code has the potential to '[minimise inefficient duplication](https://www.gov.uk/government/publications/better-broader-safer-using-health-data-for-research-and-analysis/better-broader-safer-using-health-data-for-research-and-analysis)'.
+
+### Transparency
+
+Analytic code should be routinely shared so that individuals and organisations affected by the analysis (and other interested parties) can satisfy themselves that the analysis has been conducted competently, with appropriate methods and without error.
+This is particularly useful when the data or analysis are themselves sensitive and are not shared; sharing of code can show that the analysis is done to an appropriate standard
+
+### Reliability
+
+[Open source code is often better](https://www.freecodecamp.org/news/what-is-great-about-developing-open-source-and-what-is-not/) than closed source code because the individuals working on the project know that anybody can see what they are doing.
+There is a much stronger motivation to produce high quality code but in particular to write useful and detailed documentation when there is a potentially very large audience of people reading the code in the future.
+
+### Contribution
+
+Openness means that code can be improved by outside observers, who can find and report bugs, request new features and even contribute their own code.
+This can help improve the quality of the project at little cost, allow developers to better meet user needs and even help to build a community around the project.
+
+### Education
+
+Sharing analytic code is also an important part of allowing others to learn more about both the analytic methods and the specific implementation used in an analysis.
+Open sourced code used in a real analytic task can be a highly useful way for individuals working in health and care who wish to learn more about a method to see it in an applied setting.
+
+### Repurpose
+
+Although reuse of analytic code is often put forward as a transformative benefit of open sourcing of analytic code, and although open sourcing of code does have the potential to greatly increase efficiency in this way, at the time of writing the scope to reuse analytic code 'off the shelf' is fairly limited.
+There is a profusion of different databases, analytic tasks, analytic questions and types of output, and in practice it is very rare for analytic code to be reused wholesale.
+However, there is a very significant potential to be realised from open sourcing code that can be repurposed in different organisations. Organisation B may have a different database vendor to Organisation A, and they may have a different question to answer, but if Organisation A has shared their analytic code then it is highly likely that it can be more easily repurposed with a new dataset and a new question than written from scratch.
+
+## Policy
+
+Many organisations have their own open source policies, including [the Data Science Campus](https://datasciencecampus.github.io/coding-in-the-open/) (Office for National Statistics) and [NHS England](https://github.com/nhsx/open-source-policy/blob/main/open-source-policy.md), while the Foundation for Public Code also maintains a generic [Standard for Public Code](https://standard.publiccode.net/). 
+
+We should develop and follow our own open source principles to help maximise the value of our work and make it easier for ourselves and others to contribute to it and repurpose it, driving up quality and improving efficiency. 
+
+We should:
+
+1. Be open early.
+    a. We will ensure that open source will be the default position for all coding projects.
+    b. We will always seek to agree on open sourcing code before a project begins.
+    c. We will code in the open from the beginning of a project unless there is a good reason not to
+    d. Use MIT or GPL licences for code and OGL or CC0 for documentation
+2. Open source as much as we can.
+    a. We will strive to release as much code as we can for a given project.
+    b. Code will be closed by exception and with clear justification.
+    c. We may redact elements of a project if methods are not finalised or the area is controversial.
+3. Use open source tools.
+    a. We will use tools that are free and easily obtained so that others can access and reproduce our results. This includes:
+        * Git for version control
+        * GitHub for hosting the code and for collaboration
+        * open source coding languages such as R and Python.
+4. Follow industry best practices.
+    a. Regarding coding processes, we will: 
+        * review all code contributions for quality
+        * write clear and meaningful commit message
+        * release code with semantic versioning and informative release notes
+    b. Regarding context, we will:
+        * publish clear limitations and caveats alongside our code to help prevent it from being inadvertently misused
+        * provide documentation in plain English, including an informative README
+    c. Regarding security, we will use: 
+        * appropriate controls with respect to data and credential management
+        * .gitignore templates to exclude specific files, such as data
+        * automated detection methods, such as git hooks and GitHub Actions, to protect from accidental upload
+    d. Regarding maintenance, we will:
+        * nominate and regularly update a point of contact for all of our open repositories, who will be responsible for managing issues and pull requests in a timely fashion
+        * clearly advertise and routinely reassess the status and lifecycle stage of each project, archiving but not deleting repositories if they are no longer current
+5. Build a culture of openness.
+    a. We should build an internal culture of openness, normalise and promote an ‘open by default' mentality and encourage learning and development in this area.
+    b. We should encourage interested external parties to contribute and reuse our code by publishing it with an appropriate open source licence and by keeping accessibility and inclusiveness in mind.

--- a/open-source-policy.Rproj
+++ b/open-source-policy.Rproj
@@ -1,0 +1,17 @@
+Version: 1.0
+ProjectId: f73552dd-23f2-4d71-8c41-87e0c827f54b
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+AutoAppendNewline: Yes
+StripTrailingWhitespace: Yes


### PR DESCRIPTION
Close #1, close #2, close #3.

* Added Quarto doc with policy text (with minor typographic adjustments).
* Updated CODEOWNERS.
* Changed license to CC-BY.
* Added simple README (to be updated later with a link to the deployment, etc).

In terms of frontmatter on the doc, the author is The Strategy Unit and there's a hard-coded 'published' date of today (April 25 2025) and also a 'modified' date for when there's updates.

<img src='https://github.com/user-attachments/assets/0a67e732-47fb-45bb-b4a4-55295726213a' width='500'>
