### PR TITLE
Tweak doc content and deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
-# Ignore rendered doc
+# Ignore rendered docs
 index.html
 index_files/
+README.html
 
 # History files
 .Rhistory

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # open-source-policy
 
 A Quarto document containing the open-source policy of [The Strategy Unit](https://www.strategyunitwm.nhs.uk/).
+
+The document is deployed to Posit Connect: [https://connect.strategyunitwm.nhs.uk/open-source-policy](https://connect.strategyunitwm.nhs.uk/open-source-policy).

--- a/deploy.R
+++ b/deploy.R
@@ -1,0 +1,14 @@
+deploy <- function(server_name, app_id) {
+  rsconnect::deployDoc(
+    server = server_name,
+    appId = app_id,
+    doc = "index.qmd",
+    appName = "open-source-policy",
+    appTitle = "Open Source Policy",
+    lint = FALSE,
+    forceUpdate = TRUE
+  )
+}
+
+deploy("connect.strategyunitwm.nhs.uk", 361)
+deploy("connect.su.mlcsu.org", 80)

--- a/index.qmd
+++ b/index.qmd
@@ -113,3 +113,7 @@ We should:
 ### Version {.appendix}
 
 v0.1.0
+
+### Source {.appendix}
+
+[https://github.com/The-Strategy-Unit/open-source-policy/](https://github.com/The-Strategy-Unit/open-source-policy/)

--- a/index.qmd
+++ b/index.qmd
@@ -81,7 +81,7 @@ We should:
     a. We will ensure that open source will be the default position for all coding projects.
     b. We will always seek to agree on open sourcing code before a project begins.
     c. We will code in the open from the beginning of a project unless there is a good reason not to
-    d. Use MIT or GPL licences for code and OGL or CC0 for documentation
+    d. Use [MIT](https://opensource.org/license/mit) or [GPL](https://www.gnu.org/licenses/gpl-3.0.en.html) licences for code and [OGL](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/) or [CC0](https://creativecommons.org/public-domain/cc0/) for documentation
 2. Open source as much as we can.
     a. We will strive to release as much code as we can for a given project.
     b. Code will be closed by exception and with clear justification.

--- a/index.qmd
+++ b/index.qmd
@@ -1,9 +1,9 @@
 ---
 title: Open-Source Policy
 author: "[The Strategy Unit](https://www.strategyunitwm.nhs.uk/)"
-date: 2025-04-25
+date: 2025-04-30
 date-modified: last-modified
-date-format: MMMM D YYYY
+date-format: D MMMM YYYY
 license: CC BY
 format: html
 ---

--- a/index.qmd
+++ b/index.qmd
@@ -109,3 +109,7 @@ We should:
 5. Build a culture of openness.
     a. We should build an internal culture of openness, normalise and promote an ‘open by default' mentality and encourage learning and development in this area.
     b. We should encourage interested external parties to contribute and reuse our code by publishing it with an appropriate open source licence and by keeping accessibility and inclusiveness in mind.
+
+### Version {.appendix}
+
+v0.1.0


### PR DESCRIPTION
Close #5, close #6, close #7, close #8.

* Added source (link to repo) and version number (hard-coded for now) to appendix.
* Linked to licenses.
* Linked to deployment from README.
* Added `deploy.R` script that deploys to both servers for now.
* Deployed to both servers, with today's date as the publish date.

@ChrisBeeley: are you happy with [the deployed doc](https://connect.strategyunitwm.nhs.uk/open-source-policy/) for now? If yes, I'll adjust access to 'anyone - no login required'.